### PR TITLE
Activate has_entity_name

### DIFF
--- a/custom_components/awnet_local/__init__.py
+++ b/custom_components/awnet_local/__init__.py
@@ -41,8 +41,7 @@ MAC_REGEX = r"^(?:[a-f0-9]{2}:){5}[a-f0-9]{2}$"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if not entry.unique_id:
-        hass.config_entries.async_update_entry(
-            entry, unique_id=entry.data[CONF_MAC])
+        hass.config_entries.async_update_entry(entry, unique_id=entry.data[CONF_MAC])
 
     ambient = AmbientStation(hass, entry)
 
@@ -71,8 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning("Data received for %s that is not our MAC", mac)
             return
         _LOGGER.debug(
-            "Last data: %s", hass.data[DOMAIN][entry.entry_id].stations.get(
-                mac, None)
+            "Last data: %s", hass.data[DOMAIN][entry.entry_id].stations.get(mac, None)
         )
         hass.data[DOMAIN][entry.entry_id].on_data(mac, call.data)
 
@@ -107,8 +105,7 @@ class AmbientStation:
             for attr_type in SUPPORTED_SENSOR_TYPES + SUPPORTED_BINARY_SENSOR_TYPES:
                 self.stations[mac][ATTR_LAST_DATA][attr_type] = None
             if not self._entry_setup_complete:
-                self._hass.config_entries.async_setup_platforms(
-                    self._entry, PLATFORMS)
+                self._hass.config_entries.async_setup_platforms(self._entry, PLATFORMS)
                 self._entry_setup_complete = True
 
     def on_data(self, mac: str, data: dict) -> None:
@@ -146,8 +143,8 @@ class AmbientWeatherEntity(Entity):
             manufacturer="Ambient Weather",
             name=station_name,
         )
-
-        self._attr_name = f"{station_name} {description.name}"
+        self._attr_has_entity_name = True
+        self._attr_name = f"{description.name}"
         self._attr_unique_id = f"{mac_address}_{description.key}"
         self._mac_address = mac_address
         self._attr_available = False

--- a/custom_components/awnet_local/__init__.py
+++ b/custom_components/awnet_local/__init__.py
@@ -41,7 +41,8 @@ MAC_REGEX = r"^(?:[a-f0-9]{2}:){5}[a-f0-9]{2}$"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if not entry.unique_id:
-        hass.config_entries.async_update_entry(entry, unique_id=entry.data[CONF_MAC])
+        hass.config_entries.async_update_entry(
+            entry, unique_id=entry.data[CONF_MAC])
 
     ambient = AmbientStation(hass, entry)
 
@@ -70,7 +71,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning("Data received for %s that is not our MAC", mac)
             return
         _LOGGER.debug(
-            "Last data: %s", hass.data[DOMAIN][entry.entry_id].stations.get(mac, None)
+            "Last data: %s", hass.data[DOMAIN][entry.entry_id].stations.get(
+                mac, None)
         )
         hass.data[DOMAIN][entry.entry_id].on_data(mac, call.data)
 
@@ -105,7 +107,8 @@ class AmbientStation:
             for attr_type in SUPPORTED_SENSOR_TYPES + SUPPORTED_BINARY_SENSOR_TYPES:
                 self.stations[mac][ATTR_LAST_DATA][attr_type] = None
             if not self._entry_setup_complete:
-                self._hass.config_entries.async_setup_platforms(self._entry, PLATFORMS)
+                self._hass.config_entries.async_setup_platforms(
+                    self._entry, PLATFORMS)
                 self._entry_setup_complete = True
 
     def on_data(self, mac: str, data: dict) -> None:


### PR DESCRIPTION
The "new" standard is to have self._attr_has_entity_name = True. (Required for new integrations)
Then HA creates the entity names from "device name" + "entity name".  This change should keep the names the same as before but follow the new "standard".  

Also a bit of "black" reformatting (sorry about that - it's automatic).  The "real" change is the lines 146-147